### PR TITLE
Refactor state machine + fix SWJ_Pins

### DIFF
--- a/src/dap/state.rs
+++ b/src/dap/state.rs
@@ -1,0 +1,145 @@
+use crate::{jtag, swd, swj};
+
+/// State machine of the Dap handler
+pub enum State<DEPS, SWD, JTAG> {
+    /// State that _should_ never happen.
+    ///
+    /// Assumption: No one tries to "somehow" catch the `From::from` panic for
+    /// None/SWD/JTAG.
+    Invalid,
+    /// None/uninitialized/direct mode
+    ///
+    /// Used to execute CMSIS DAP commands that rely on a direct pin
+    /// manipulation
+    None {
+        mode_to_restore: DynState,
+        deps: DEPS,
+    },
+    /// SWD mode
+    Swd(SWD),
+    /// JTAG mode
+    Jtag(JTAG),
+}
+
+/// Plain enum describing the current state
+///
+/// Used to record the previous non-`None` mode in order to restore in
+/// [`State::to_last_mode`]
+pub enum DynState {
+    None,
+    Swd,
+    Jtag,
+}
+
+impl<DEPS, SWD, JTAG> State<DEPS, SWD, JTAG>
+where
+    DEPS: swj::Dependencies<SWD, JTAG>,
+    SWD: swd::Swd<DEPS>,
+    JTAG: jtag::Jtag<DEPS>,
+{
+    /// Change the clock configuration
+    pub fn set_clock(&mut self, max_frequency: u32) -> bool {
+        match self {
+            State::None { deps, .. } => deps.process_swj_clock(max_frequency),
+            // TODO: I think this is wrong or at least barely applicable approach.
+            // `Swd` if running eg. SPI won't be able to change it's clock on fly
+            // Switch to `None` and back will be probably necessary and this is also
+            // what should be done here?
+            State::Swd(v) => v.set_clock(max_frequency),
+            State::Jtag(v) => v.set_clock(max_frequency),
+            State::Invalid => unreachable!(),
+        }
+    }
+}
+
+impl<DEPS, SWD, JTAG> State<DEPS, SWD, JTAG>
+where
+    DEPS: From<SWD> + From<JTAG>,
+    SWD: From<DEPS>,
+    JTAG: From<DEPS>,
+{
+    /// Construct an instance of [`State`] object
+    pub fn new(deps: DEPS) -> Self {
+        Self::None {
+            deps,
+            mode_to_restore: DynState::None,
+        }
+    }
+
+    /// Force the state transition to `None`.
+    ///
+    /// Useful for commands that rely on the direct pin control.
+    pub fn to_none(&mut self) {
+        match self {
+            State::None { .. } => {}
+            state => state.replace_with(|s| match s {
+                State::Swd(v) => State::None {
+                    deps: v.into(),
+                    mode_to_restore: DynState::Swd,
+                },
+                State::Jtag(v) => State::None {
+                    deps: v.into(),
+                    mode_to_restore: DynState::Jtag,
+                },
+                State::Invalid | State::None { .. } => unreachable!(),
+            }),
+        }
+    }
+
+    /// Force the state transition to the last non-`None` mode.
+    ///
+    /// Useful for commands that do the proper data transmition in SWD/JTAG mode
+    pub fn to_last_mode(&mut self) {
+        match self {
+            State::Swd(_) | State::Jtag(_) => {}
+            state @ State::None { .. } => state.replace_with(|s| match s {
+                State::None {
+                    mode_to_restore,
+                    deps,
+                } => match mode_to_restore {
+                    DynState::None => State::None {
+                        mode_to_restore,
+                        deps,
+                    },
+                    DynState::Swd => State::Swd(deps.into()),
+                    DynState::Jtag => State::Jtag(deps.into()),
+                },
+                State::Swd(_) | State::Jtag(_) | State::Invalid => unreachable!(),
+            }),
+            State::Invalid => unreachable!(),
+        }
+    }
+
+    /// Force the state transition to SWD.
+    ///
+    /// Useful for commands that specify the transmission protocol to be SWD.
+    pub fn to_swd(&mut self) {
+        match self {
+            State::Swd(_) => {}
+            state => state.replace_with(|s| match s {
+                State::None { deps, .. } => State::Swd(deps.into()),
+                State::Jtag(v) => State::Swd(DEPS::from(v).into()),
+                State::Swd(_) | State::Invalid => unreachable!(),
+            }),
+        }
+    }
+
+    /// Force the state transition to JTAG.
+    ///
+    /// Useful for commands that specify the transmission protocol to be JTAG.
+    pub fn to_jtag(&mut self) {
+        match self {
+            State::Jtag(_) => {}
+            state => state.replace_with(|s| match s {
+                State::None { deps, .. } => State::Jtag(deps.into()),
+                State::Swd(v) => State::Jtag(DEPS::from(v).into()),
+                State::Jtag(_) | State::Invalid => unreachable!(),
+            }),
+        }
+    }
+
+    #[inline(always)]
+    fn replace_with<F: FnOnce(Self) -> Self>(&mut self, f: F) {
+        replace_with::replace_with(self, || State::Invalid, f);
+    }
+}

--- a/src/jtag.rs
+++ b/src/jtag.rs
@@ -1,14 +1,6 @@
-use crate::dap::DapContext;
-
-pub trait Jtag<CONTEXT: DapContext> {
+pub trait Jtag<DEPS>: From<DEPS> {
     /// If JTAG is available or not.
     const AVAILABLE: bool;
-
-    /// Create the JTAG from context
-    fn new(context: CONTEXT) -> Self;
-
-    /// Release the context from the JTAG
-    fn release(self) -> CONTEXT;
 
     /// Handle a JTAG sequence request.
     fn sequences(&mut self, data: &[u8], rxbuf: &mut [u8]) -> u32;

--- a/src/swd.rs
+++ b/src/swd.rs
@@ -1,4 +1,3 @@
-use crate::dap::DapContext;
 use num_enum::{IntoPrimitive, TryFromPrimitive};
 
 /// The available errors for SWD.
@@ -102,18 +101,9 @@ pub enum DataPhase {
 }
 
 /// Definition of SWD communication.
-pub trait Swd<CONTEXT: DapContext> {
+pub trait Swd<DEPS>: From<DEPS> {
     /// If SWD is available or not.
     const AVAILABLE: bool;
-
-    /// Create the SWD from context
-    fn new(context: CONTEXT) -> Self;
-
-    /// Release the context from the SWD
-    fn release(self) -> CONTEXT;
-
-    /// Configure SWD, return true if the configuration was successful.
-    fn configure(&mut self, period: TurnaroundPeriod, data_phase: DataPhase) -> bool;
 
     /// Helper method over `read_inner` to retry during `AckWait`.
     fn read(&mut self, wait_retries: usize, apndp: APnDP, a: DPRegister) -> Result<u32> {

--- a/src/swj.rs
+++ b/src/swj.rs
@@ -18,15 +18,21 @@ bitflags! {
     }
 }
 
-/// Trait for SWJ, as it is now only the SWJ_Pins command is handled here,
-/// clock speed is part of the JTAG and SWD traits.
-pub trait Swj {
+// TODO: Change the name? Move it to a different module?
+/// Trait describing the dependencies necessary to yield an instance of
+/// [`crate::Dap`]
+///
+/// User has to provide implementations of SWJ_{Pins, Sequence, Clock} commands
+pub trait Dependencies<SWD, JTAG>: From<SWD> + From<JTAG> {
     /// Runner for SWJ_Pins commands.
-    fn pins(&mut self, output: Pins, mask: Pins, wait_us: u32) -> Pins;
+    fn process_swj_pins(&mut self, output: Pins, mask: Pins, wait_us: u32) -> Pins;
 
     /// Runner for SWJ_Pins commands.
-    fn sequence(&mut self, data: &[u8], nbits: usize);
+    fn process_swj_sequence(&mut self, data: &[u8], nbits: usize);
 
     /// Set the maximum clock frequency, return `true` if it is valid.
-    fn set_clock(&mut self, max_frequency: u32) -> bool;
+    fn process_swj_clock(&mut self, max_frequency: u32) -> bool;
+
+    /// Set pins in high impedance mode
+    fn high_impedance_mode(&mut self);
 }


### PR DESCRIPTION
Before the refactor both `Jtag` and `Swd` were assuming the ownership of the `Context`. Now, all three are expected to know how to convert from one another which should better support the use case where internal fields are less dynamic type-wise (type-states, SPI used in SWD mode that has to be deconstructed on a switch and own the pins etc.).

Now, DAP state is supposed to be changed lazily; that is only when currently executed command requires a different mode/state, the switch will occur. This enables the correct implementation of the SWJ_Pins command that is supposed to maintain the requested state of the pins until another command arrives.