### PR TITLE
Add support for SWD sequence

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dap-rs"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = [
     "Emil Fresk <emil.fresk@gmail.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dap-rs"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 authors = [
     "Emil Fresk <emil.fresk@gmail.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ usb-device = { version = "0.3.1", features = ["control-buffer-256"] }
 embedded-hal = "1.0.0"
 replace_with = { version = "0.1.7", default-features = false, features = ["panic_abort"] }
 bitflags = "1.3.2"
+
+[dev-dependencies]
 mockall = "0.13.0"
 
 [dependencies.defmt]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ usb-device = { version = "0.3.1", features = ["control-buffer-256"] }
 embedded-hal = "1.0.0"
 replace_with = { version = "0.1.7", default-features = false, features = ["panic_abort"] }
 bitflags = "1.3.2"
+mockall = "0.13.0"
 
 [dependencies.defmt]
 optional = true

--- a/src/dap.rs
+++ b/src/dap.rs
@@ -855,3 +855,130 @@ impl<T> CheckResult<T> for swd::Result<T> {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::mock_device::*;
+    use mockall::predicate::*;
+
+    struct FakeLEDs {}
+    impl DapLeds for FakeLEDs {
+        fn react_to_host_status(&mut self, _host_status: HostStatus) {}
+    }
+
+    struct StdDelayUs{}
+    impl DelayUs<u32> for StdDelayUs {
+        fn delay_us(&mut self, us: u32) {
+            std::thread::sleep(std::time::Duration::from_micros(us as u64));
+        }
+    }
+
+    type TestDap<'a> = Dap<'a, MockSwdJtagDevice, FakeLEDs, StdDelayUs, MockSwdJtagDevice, MockSwdJtagDevice, swo::MockSwo>;
+
+    #[test]
+    fn test_swd_output_reset() {
+        let mut dap = TestDap::new(
+            MockSwdJtagDevice::new(),
+            FakeLEDs{},
+            StdDelayUs{},
+            None,
+            "test_dap"
+        );
+
+        let report = [0x1Du8, 52, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xC0];
+        let mut rbuf = [0u8; 64];
+        dap.state.to_swd();
+        match &mut dap.state {
+            State::Swd(swd) => {
+                swd.expect_write_sequence().once().with(eq(52), eq([0xFFu8, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xC0])).return_const(Ok(()));
+            },
+            _ => assert!(false, "can't switch to swd"),
+        }
+        let rsize = dap.process_command(&report, &mut rbuf, DapVersion::V2);
+        assert_eq!(rsize, 2);
+        assert_eq!(&rbuf[..2], &[0x1Du8, 0x00])
+    }
+
+    #[test]
+    fn test_swd_output_max_size() {
+        let mut dap = TestDap::new(
+            MockSwdJtagDevice::new(),
+            FakeLEDs{},
+            StdDelayUs{},
+            None,
+            "test_dap"
+        );
+
+        let report = [0x1Du8, 0, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xC0, 0x00];
+        let mut rbuf = [0u8; 64];
+        dap.state.to_swd();
+        match &mut dap.state {
+            State::Swd(swd) => {
+                swd.expect_write_sequence().once().with(eq(64), eq([0xFFu8, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xC0, 0x00])).return_const(Ok(()));
+            },
+            _ => assert!(false, "can't switch to swd"),
+        }
+        let rsize = dap.process_command(&report, &mut rbuf, DapVersion::V2);
+        assert_eq!(rsize, 2);
+        assert_eq!(&rbuf[..2], &[0x1Du8, 0x00])
+    }
+
+    #[test]
+    fn test_swd_input() {
+        let mut dap = TestDap::new(
+            MockSwdJtagDevice::new(),
+            FakeLEDs{},
+            StdDelayUs{},
+            None,
+            "test_dap"
+        );
+
+        let report = [0x1Du8, 0x80 | 52];
+        let mut rbuf = [0u8; 64];
+        dap.state.to_swd();
+        match &mut dap.state {
+            State::Swd(swd) => {
+                swd.expect_read_sequence().once().withf(|nbits, buf| {
+                    buf.len() >= 7 && *nbits == 52
+                }).returning(|_, buf| {
+                    buf[..7].clone_from_slice(&[0xFFu8, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xC0]);
+                    Ok(())
+                });
+            },
+            _ => assert!(false, "can't switch to swd"),
+        }
+        let rsize = dap.process_command(&report, &mut rbuf, DapVersion::V2);
+        assert_eq!(rsize, 9);
+        assert_eq!(&rbuf[..9], &[0x1Du8, 0x00, 0xFFu8, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xC0])
+    }
+
+    #[test]
+    fn test_swd_input_max_size() {
+        let mut dap = TestDap::new(
+            MockSwdJtagDevice::new(),
+            FakeLEDs{},
+            StdDelayUs{},
+            None,
+            "test_dap"
+        );
+
+        let report = [0x1Du8, 0x80];
+        let mut rbuf = [0u8; 64];
+        dap.state.to_swd();
+        match &mut dap.state {
+            State::Swd(swd) => {
+                swd.expect_read_sequence().once().withf(|nbits, buf| {
+                    buf.len() >= 8 && *nbits == 64
+                }).returning(|_, buf| {
+                    buf[..8].clone_from_slice(&[0xFFu8, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xC0, 0x00]);
+                    Ok(())
+                });
+            },
+            _ => assert!(false, "can't switch to swd"),
+        }
+        let rsize = dap.process_command(&report, &mut rbuf, DapVersion::V2);
+        assert_eq!(rsize, 10);
+        assert_eq!(&rbuf[..10], &[0x1Du8, 0x00, 0xFFu8, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xC0, 0x00])
+    }
+}

--- a/src/dap/request.rs
+++ b/src/dap/request.rs
@@ -33,6 +33,10 @@ impl<'a> Request<'a> {
         value
     }
 
+    pub fn consume(&mut self, count: usize) {
+        self.data = &self.data[count..];
+    }
+
     pub fn rest(self) -> &'a [u8] {
         &self.data
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,6 @@
 //! TODO: Crate docs
 
-#![no_std]
+#![cfg_attr(not(test), no_std)]
 #![warn(missing_docs)]
 
 /// TODO: Dap docs
@@ -10,6 +10,9 @@ pub mod swd;
 pub mod swj;
 pub mod swo;
 pub mod usb;
+
+#[cfg(test)]
+mod mock_device;
 
 // Re-export the usb-device crate, so that crates depending on us can use it without
 // having to track it as a separate dependency.

--- a/src/mock_device.rs
+++ b/src/mock_device.rs
@@ -1,0 +1,76 @@
+use crate::{jtag, swd, swj};
+
+#[mockall::automock]
+pub trait SwdJtagDevice {
+    // swj
+    fn high_impedance_mode(&mut self);
+    fn process_swj_clock(&mut self, max_frequency: u32) -> bool;
+    fn process_swj_pins(&mut self, output: swj::Pins, mask: swj::Pins, wait_us: u32) -> swj::Pins;
+    fn process_swj_sequence(&mut self, data: &[u8], nbits: usize);
+
+    // swd
+    fn read_inner(&mut self, apndp: swd::APnDP, a: swd::DPRegister) -> swd::Result<u32>;
+    fn write_inner(&mut self, apndp: swd::APnDP, a: swd::DPRegister, data: u32) -> swd::Result<()>;
+    fn read_sequence(&mut self, num_bits: usize, data: &mut [u8]) -> swd::Result<()>;
+    fn write_sequence(&mut self, num_bits: usize, data: &[u8]) -> swd::Result<()>;
+
+    // jtag
+    fn sequences(&mut self, data: &[u8], rxbuf: &mut [u8]) -> u32;
+
+    // swd/jtag
+    fn set_clock(&mut self, max_frequency: u32) -> bool;
+}
+
+impl swj::Dependencies<Self, Self> for MockSwdJtagDevice {
+    fn high_impedance_mode(&mut self) {
+        SwdJtagDevice::high_impedance_mode(self)
+    }
+
+    fn process_swj_clock(&mut self, max_frequency: u32) -> bool {
+        SwdJtagDevice::process_swj_clock(self, max_frequency)
+    }
+
+    fn process_swj_pins(&mut self, output: swj::Pins, mask: swj::Pins, wait_us: u32) -> swj::Pins {
+        SwdJtagDevice::process_swj_pins(self, output, mask, wait_us)
+    }
+
+    fn process_swj_sequence(&mut self, data: &[u8], nbits: usize) {
+        SwdJtagDevice::process_swj_sequence(self, data, nbits)
+    }
+}
+
+impl swd::Swd<Self> for MockSwdJtagDevice {
+    const AVAILABLE: bool = true;
+
+    fn set_clock(&mut self, max_frequency: u32) -> bool {
+        SwdJtagDevice::set_clock(self, max_frequency)
+    }
+
+    fn read_inner(&mut self, apndp: swd::APnDP, a: swd::DPRegister) -> swd::Result<u32> {
+        SwdJtagDevice::read_inner(self, apndp, a)
+    }
+
+    fn write_inner(&mut self, apndp: swd::APnDP, a: swd::DPRegister, data: u32) -> swd::Result<()> {
+        SwdJtagDevice::write_inner(self, apndp, a, data)
+    }
+
+    fn read_sequence(&mut self, num_bits: usize, data: &mut [u8]) -> swd::Result<()> {
+        SwdJtagDevice::read_sequence(self, num_bits, data)
+    }
+
+    fn write_sequence(&mut self, num_bits: usize, data: &[u8]) -> swd::Result<()> {
+        SwdJtagDevice::write_sequence(self, num_bits, data)
+    }
+}
+
+impl jtag::Jtag<MockSwdJtagDevice> for MockSwdJtagDevice {
+    const AVAILABLE: bool = true;
+
+    fn set_clock(&mut self, max_frequency: u32) -> bool {
+        SwdJtagDevice::set_clock(self, max_frequency)
+    }
+
+    fn sequences(&mut self, data: &[u8], rxbuf: &mut [u8]) -> u32 {
+        SwdJtagDevice::sequences(self, data, rxbuf)
+    }
+}

--- a/src/swd.rs
+++ b/src/swd.rs
@@ -152,6 +152,12 @@ pub trait Swd<DEPS>: From<DEPS> {
 
     /// Set the maximum clock frequency, return `true` if it is valid.
     fn set_clock(&mut self, max_frequency: u32) -> bool;
+
+    /// Write a sequence of bits using SWDIO and the clock line running at the configured freq.
+    fn write_sequence(&mut self, num_bits: usize, data: &[u8]) -> Result<()>;
+
+    /// Read a sequence of bits using SWDIO and the clock line running at the configured freq.
+    fn read_sequence(&mut self, num_bits: usize, data: &mut [u8]) -> Result<()>;
 }
 
 /// Helper used by `Swd::read_inner` and `Swd::write_inner` to make the request byte.

--- a/src/swo.rs
+++ b/src/swo.rs
@@ -42,6 +42,7 @@ pub struct SwoStatus {
     pub bytes_available: u32,
 }
 
+#[cfg_attr(test, mockall::automock)]
 pub trait Swo {
     fn set_transport(&mut self, transport: SwoTransport);
     fn set_mode(&mut self, mode: SwoMode);


### PR DESCRIPTION
Process SWD sequence commands to pass them down to the device.

I changed the version to 0.2.0 instead of 0.1.1 because I modified the Swd trait, which would break dependent crates.

Changes:
- Added code to process an swd sequence command and translate to swd trait functions
- Modified the Swd trait to support swd sequence commands
- Added mocking to be able to test the dap protocol without hardware

Testing:
- Unit tests to test some cases of the swd sequence commands.

Related Issues:
- Addresses #3 