### PR TITLE
Refactor interface availability code

### DIFF
--- a/src/jtag.rs
+++ b/src/jtag.rs
@@ -183,8 +183,8 @@ const DAP_TRANSFER_OK_FAULT: u32 = 0x02;
 
 /// JTAG interface.
 pub trait Jtag<DEPS>: From<DEPS> {
-    /// If JTAG is available or not.
-    const AVAILABLE: bool;
+    /// Returns whether JTAG is available or not.
+    fn available(deps: &DEPS) -> bool;
 
     /// Returns a mutable reference to the JTAG interface configuration.
     fn config(&mut self) -> &mut Config;

--- a/src/mock_device.rs
+++ b/src/mock_device.rs
@@ -51,7 +51,9 @@ impl swj::Dependencies<Self, Self> for MockSwdJtagDevice {
 }
 
 impl swd::Swd<Self> for MockSwdJtagDevice {
-    const AVAILABLE: bool = true;
+    fn available(_: &Self) -> bool {
+        true
+    }
 
     fn set_clock(&mut self, max_frequency: u32) -> bool {
         SwdJtagDevice::set_clock(self, max_frequency)
@@ -79,7 +81,9 @@ impl swd::Swd<Self> for MockSwdJtagDevice {
 }
 
 impl jtag::Jtag<MockSwdJtagDevice> for MockSwdJtagDevice {
-    const AVAILABLE: bool = true;
+    fn available(_: &Self) -> bool {
+        true
+    }
 
     fn set_clock(&mut self, max_frequency: u32) -> bool {
         SwdJtagDevice::set_clock(self, max_frequency)

--- a/src/swd.rs
+++ b/src/swd.rs
@@ -111,8 +111,8 @@ impl Default for Config {
 
 /// Definition of SWD communication.
 pub trait Swd<DEPS>: From<DEPS> {
-    /// If SWD is available or not.
-    const AVAILABLE: bool;
+    /// Returns whether SWD is available or not.
+    fn available(deps: &DEPS) -> bool;
 
     /// Returns a mutable reference to the SWD interface configuration.
     fn config(&mut self) -> &mut Config;

--- a/src/swo.rs
+++ b/src/swo.rs
@@ -29,8 +29,12 @@ pub enum SwoControl {
 #[derive(Copy, Clone, Debug)]
 #[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct SwoSupport {
+    /// `true` if the UART encoding is supported.
     pub uart: bool,
+    /// `true` if the Manchester encoding is supported.
     pub manchester: bool,
+    /// `true` if the USB interface has a trace endpoint.
+    pub streaming: bool,
 }
 
 #[derive(Copy, Clone, Debug)]
@@ -42,12 +46,11 @@ pub struct SwoStatus {
     pub bytes_available: u32,
 }
 
-#[cfg_attr(test, mockall::automock)]
 pub trait Swo {
-    fn set_transport(&mut self, transport: SwoTransport);
-    fn set_mode(&mut self, mode: SwoMode);
+    fn set_transport(&mut self, transport: SwoTransport) -> bool;
+    fn set_mode(&mut self, mode: SwoMode) -> bool;
     fn set_baudrate(&mut self, baudrate: u32) -> u32;
-    fn set_control(&mut self, control: SwoControl);
+    fn set_control(&mut self, control: SwoControl) -> bool;
     fn polling_data(&mut self, buf: &mut [u8]) -> u32;
     fn streaming_data(&mut self); //  -> SomeBufferFromStreaming; // TODO: What is a good interface?
     fn is_active(&self) -> bool;
@@ -55,4 +58,50 @@ pub trait Swo {
     fn buffer_size(&self) -> u32;
     fn support(&self) -> SwoSupport;
     fn status(&mut self) -> SwoStatus;
+}
+
+/// Marker struct for no SWO support.
+pub struct NoSwo;
+
+impl Swo for NoSwo {
+    fn set_transport(&mut self, _transport: SwoTransport) -> bool {
+        false
+    }
+    fn set_mode(&mut self, _mode: SwoMode) -> bool {
+        false
+    }
+    fn set_baudrate(&mut self, _baudrate: u32) -> u32 {
+        0
+    }
+    fn set_control(&mut self, _control: SwoControl) -> bool {
+        false
+    }
+    fn polling_data(&mut self, _buf: &mut [u8]) -> u32 {
+        0
+    }
+    fn streaming_data(&mut self) {}
+    fn is_active(&self) -> bool {
+        false
+    }
+    fn bytes_available(&self) -> u32 {
+        0
+    }
+    fn buffer_size(&self) -> u32 {
+        0
+    }
+    fn support(&self) -> SwoSupport {
+        SwoSupport {
+            uart: false,
+            manchester: false,
+            streaming: false,
+        }
+    }
+    fn status(&mut self) -> SwoStatus {
+        SwoStatus {
+            active: false,
+            trace_error: false,
+            trace_overrun: false,
+            bytes_available: 0,
+        }
+    }
 }


### PR DESCRIPTION
This PR builds on top of #8 and enables [bitbang-dap](https://github.com/bugadani/bitbang-dap) to set the correct capabilities based on how many pins the user provides to the constructor (in theory, unimplemented atm.).

The SWO changes allow users to:
- Omit a bunch of boilerplate if they don't need SWO support
- Correctly set the streaming trace capability. This is a best guess on my part of what this bit means, based on ["support for streaming SWO trace is provided via an additional USB endpoint"](https://arm-software.github.io/CMSIS-DAP/latest/dap_firmware.html#dap_bulk_usb).
- I'm trying to come up with a way to dynamically make SWO available if there are pins available (e.g. if the probe has 4 pins, allow SWD+SWO or JTAG+no-swo). I may end up not actually doing this, but this PR takes a step in that direction.