### PR TITLE
Generate timestamps if available

### DIFF
--- a/src/jtag.rs
+++ b/src/jtag.rs
@@ -186,6 +186,11 @@ pub trait Jtag<DEPS>: From<DEPS> {
     /// Returns whether JTAG is available or not.
     fn available(deps: &DEPS) -> bool;
 
+    /// Returns the current timestamp.
+    fn timestamp(&self) -> u32 {
+        0
+    }
+
     /// Returns a mutable reference to the JTAG interface configuration.
     fn config(&mut self) -> &mut Config;
 

--- a/src/mock_device.rs
+++ b/src/mock_device.rs
@@ -2,6 +2,8 @@ use crate::{jtag, swd, swj};
 
 #[mockall::automock]
 pub trait SwdJtagDevice {
+    fn timer_available(&self) -> bool;
+
     // swj
     fn high_impedance_mode(&mut self);
     fn process_swj_clock(&mut self, max_frequency: u32) -> bool;
@@ -25,6 +27,10 @@ pub trait SwdJtagDevice {
 }
 
 impl swj::Dependencies<Self, Self> for MockSwdJtagDevice {
+    fn timer_available(&self) -> bool {
+        SwdJtagDevice::timer_available(self)
+    }
+
     fn high_impedance_mode(&mut self) {
         SwdJtagDevice::high_impedance_mode(self)
     }

--- a/src/swd.rs
+++ b/src/swd.rs
@@ -114,6 +114,11 @@ pub trait Swd<DEPS>: From<DEPS> {
     /// Returns whether SWD is available or not.
     fn available(deps: &DEPS) -> bool;
 
+    /// Returns the current timestamp.
+    fn timestamp(&self) -> u32 {
+        0
+    }
+
     /// Returns a mutable reference to the SWD interface configuration.
     fn config(&mut self) -> &mut Config;
 

--- a/src/swj.rs
+++ b/src/swj.rs
@@ -26,6 +26,11 @@ bitflags! {
 ///
 /// User has to provide implementations of SWJ_{Pins, Sequence, Clock} commands
 pub trait Dependencies<SWD, JTAG>: From<SWD> + From<JTAG> {
+    /// Returns true if the device can generate timestamps.
+    fn timer_available(&self) -> bool {
+        false
+    }
+
     /// Runner for SWJ_Pins commands.
     fn process_swj_pins(&mut self, output: Pins, mask: Pins, wait_us: u32) -> Pins;
 


### PR DESCRIPTION
This PR implements optional timestamp support by adding a function to Dependencies (to query whether a timer is available) and one function to Swd and Jtag each to get the current timestamp.