### PR TITLE
Handle no-ack

### DIFF
--- a/src/dap.rs
+++ b/src/dap.rs
@@ -1229,6 +1229,10 @@ impl<T> CheckResult<T> for swd::Result<T> {
                 *resp = 4;
                 None
             }
+            Err(swd::Error::NoAck) => {
+                *resp = 7;
+                None
+            }
             Err(_) => {
                 *resp = (1 << 3) | 7;
                 None

--- a/src/driver/bitbang.rs
+++ b/src/driver/bitbang.rs
@@ -179,6 +179,10 @@ where
                 clock_only!(self); // turnaround cycle
                 return Err(swd::Error::AckFault);
             }
+            0b111 => {
+                clock_only!(self); // turnaround cycle
+                return Err(swd::Error::NoAck);
+            }
             _ => {
                 clock_only!(self); // turnaround cycle
                 return Err(swd::Error::AckUnknown(ack as u8));

--- a/src/swd.rs
+++ b/src/swd.rs
@@ -10,6 +10,8 @@ pub enum Error {
     AckWait,
     /// A fault.
     AckFault,
+    /// Not acknowledged.
+    NoAck,
     /// A protocol error.
     AckProtocol,
     /// Unkown error.
@@ -62,7 +64,7 @@ pub enum Ack {
     Ok = 0b001,
     Wait = 0b010,
     Fault = 0b100,
-    Protocol = 0b111,
+    NoAck = 0b111,
 }
 
 impl Ack {
@@ -72,7 +74,7 @@ impl Ack {
             v if v == (Ack::Ok as u8) => Ok(()),
             v if v == (Ack::Wait as u8) => Err(Error::AckWait),
             v if v == (Ack::Fault as u8) => Err(Error::AckFault),
-            v if v == (Ack::Protocol as u8) => Err(Error::AckProtocol),
+            v if v == (Ack::NoAck as u8) => Err(Error::NoAck),
             _ => Err(Error::AckUnknown(ack)),
         }
     }


### PR DESCRIPTION
See documentation for e.g. `DAP_transfer`: https://arm-software.github.io/CMSIS_5/DAP/html/group__DAP__Transfer.html

>   Bit 2..0: ACK (Acknowledge) value:
> 
>     1 = OK (for SWD protocol), OK or FAULT (for JTAG protocol),
>     2 = WAIT
>     4 = FAULT
>     7 = NO_ACK (no response from target)

That also matches the ARM Debug Interface spec, where protocol error is used for cases like a parity error or the stop bit being wrong. 

This makes it possible for probe-rs to handle NoAck differently from protocol errors.